### PR TITLE
fixed profile image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   <div class="portrait">
     <a href="https://arshxb.github.io/home/">
       <div class="spinner"></div>
-      <div class="img" style="background-image: url('/images/1638336701613.jpg')"></div>
+      <div class="img" style="background-image: url('/home/images/1638336701613.jpg')"></div>
     </a>
   </div>
   <h1 class="name">Arshdeep <b>Singh</b></h1>


### PR DESCRIPTION
The hugo theme does not function as expected when the site is served from a subdirectory as in our case ->
baseURL = 'https://github.io/home/'

fixed the image url for the time being by prefixing the subdirectory